### PR TITLE
Add code of conduct, issue templates, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report an error or broken link in the handbook
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear description of the issue (e.g., broken link, formatting error, incorrect information).
+
+## Location
+
+Which document or section has the issue?
+
+- Document: [e.g. foundation/mission.md]
+- Section: [e.g. "Why We Exist"]
+
+## Expected Content
+
+What should it say or link to?
+
+## Actual Content
+
+What does it currently say or link to?
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Content Proposal
+about: Suggest new content, a new section, or changes to existing documents
+title: '[PROPOSAL] '
+labels: enhancement
+assignees: ''
+---
+
+## What's Missing or Could Be Better?
+
+Describe what you think the handbook is missing or what could be improved.
+
+## Proposed Change
+
+Describe what you'd like to see added or changed. Be as specific as you can.
+
+## Why This Matters
+
+How does this change serve the community or strengthen the handbook?
+
+## Relevant Documents
+
+List any existing documents this relates to (e.g., `governance/governance.md`).
+
+## Would you like to work on this?
+
+- [ ] Yes, I'd like to write this
+- [ ] No, just suggesting

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Description
+
+Please include a summary of the changes and the related issue.
+
+Fixes # (issue number)
+
+## Type of Change
+
+- [ ] Correction (fixing an error, broken link, or typo)
+- [ ] Content update (improving existing document)
+- [ ] New content (adding a new document or section)
+- [ ] Translation
+- [ ] Structural change (reorganizing documents)
+
+## Changes Made
+
+-
+-
+-
+
+## Voice & Tone Checklist
+
+- [ ] Writing is direct and human (not corporate or committee-speak)
+- [ ] Changes feel continuous with the existing handbook voice
+- [ ] Content is specific and actionable, not vague
+
+## Checklist
+
+- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
+- [ ] Changes are focused (one idea per PR)
+- [ ] Document status header is updated if applicable
+- [ ] I have performed a self-review of my changes
+
+## Context
+
+Add any context about why this change matters to the community.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,42 @@
+# Code of Conduct
+
+## Our Commitment
+
+PhilaCon Valley is a community for Black, Brown, LGBTQIA+, and underrepresented technologists in Philadelphia. We are committed to providing a welcoming, safe, and inclusive space for everyone — regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+**We expect:**
+
+- Empathy and kindness toward other people
+- Respect for differing opinions, viewpoints, and experiences
+- Constructive feedback, given and received gracefully
+- Accountability for mistakes, with a focus on learning
+- Decisions that prioritize the community over individuals
+
+**We do not tolerate:**
+
+- Sexualized language or imagery, or unwelcome sexual attention
+- Trolling, insulting or derogatory comments, personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Conduct that would be considered inappropriate in a professional or community setting
+
+## Scope
+
+This Code of Conduct applies in all PhilaCon Valley community spaces — GitHub, events, Slack, social media, and anywhere someone is representing the community.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to community leaders at **waskar@philaconvalley.com**. All complaints will be reviewed and investigated promptly and fairly. Community leaders are obligated to respect the privacy and security of the reporter.
+
+### Consequences
+
+1. **Correction** — A private written warning with clarity about the violation.
+2. **Warning** — A warning with consequences for continued behavior, including no interaction with involved parties for a specified period.
+3. **Temporary Ban** — Temporary removal from community spaces.
+4. **Permanent Ban** — Permanent removal from community spaces.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ Communities grow quickly. Writing down our philosophy helps protect the culture 
 
 This handbook belongs to the community. If you have a suggestion, a correction, or something you think is missing — we want to hear it.
 
+**You don't need to be a developer to contribute.** If you can read a document and have a thought about it, you can help. Look for issues labeled `good first issue` to get started.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to get involved.
+
+## Code of Conduct
+
+All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md). PhilaCon Valley is committed to providing a welcoming, safe, and inclusive space for everyone.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add CODE_OF_CONDUCT.md tailored to PhilaCon Valley's mission
- Add issue templates (bug report for doc errors + content proposal for new ideas)
- Add PR template with Voice & Tone checklist

## Why
Standardize the contribution experience so community members know how to suggest changes, report issues, and submit pull requests — while maintaining the handbook's direct, human voice.

## Files Added
- `CODE_OF_CONDUCT.md`
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

## Test plan
- [ ] Verify issue templates appear when creating a new issue on GitHub
- [ ] Verify PR template auto-fills when opening a new pull request
- [ ] Review CODE_OF_CONDUCT.md contact info is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)