### PR TITLE
[Docs] Add Acknowledgments / Contributor Recognition section

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,9 @@ All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md
 - [Meetup](https://www.meetup.com/philaconvalley/)
 - [Luma](https://lu.ma/philaconvalley)
 - [LinkedIn](https://www.linkedin.com/company/philaconvalley/)
+
+## Acknowledgments
+
+Thank you to all the community members who have contributed to this handbook through feedback, discussions, and pull requests. This is a living document shaped by the PhilaCon Valley community.
+
+If you've contributed and would like to be recognized, please open a pull request to add your name to this section.


### PR DESCRIPTION
## Summary

Adds an Acknowledgments section to the README, as requested in philaconvalley/community-handbook#5.

## Changes

- Added `## Acknowledgments` section at the end of README.md
- Includes a placeholder for community contributors to add their names via PR

Closes philaconvalley/community-handbook#5