### PR TITLE
Update handbook: structure, boundary policy, event names, vision statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the PhilaCon Valley Community Handbook are documented her
 
 ---
 
+## [1.1.1] — 2026-08-15
+
+Two corrections found by comparing the handbook against how PhilaCon Valley actually operates.
+
+### Changed
+- `event-philosophy.md` — Replaced "Builder Nights" with **PATCH**, the name of the build-night series that has actually run twice (PATCH 001, PATCH 002) since June 2026. Marked Workshops, Vision Labs, Hackathons, and The Giveback as formats we're building toward rather than implying all five are already running.
+- `builder-philosophy.md` — Added "The line between the two tracks stays a line," naming the boundary rule that keeps nonprofit community programming from becoming a sales funnel for the agency arm: the nonprofit never starts the commercial conversation, community members get no pricing advantage, and a crossover from community to client work is said out loud instead of happening quietly.
+- `README.md`, `CONTRIBUTING.md` — Updated the Discord invite link (old one replaced with `discord.gg/5haHYh5xcx`) in all three places it appeared.
+- `foundation/vision.md` — Added, new document: "What We Believe," a full vision statement built entirely from language already used across the handbook (Mission, Principles, Community Values, Builder Philosophy, Event Philosophy, AI Principles) and the community's own comms (PATCH, "By us, for us"). Linked from README's Foundation section. Revised same day: swapped a borrowed Apple line for PhilaCon Valley's own ("building things that matter, with people we trust, in a city we love") and broadened the language from code-only to creative-technology — sound, visuals, brand, hardware — to match what PATCH 001, NFC Lab, and the design work actually are.
+- `ai-principles.md` — Named **agentic engineering** as the ongoing AI skill the community builds around, and noted that a "vibe coding" session was a one-time workshop format, not the community's identity.
+
+---
+
 ## [1.1.0] — 2026-08-15
 
 The handbook's structure layer updated to match how PhilaCon Valley actually operates five months after the 1.0.0 release. The values and philosophy layer (mission, principles, community values, AI principles, event philosophy) needed almost no change — it held up.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the PhilaCon Valley Community Handbook are documented her
 
 ---
 
+## [1.1.0] — 2026-08-15
+
+The handbook's structure layer updated to match how PhilaCon Valley actually operates five months after the 1.0.0 release. The values and philosophy layer (mission, principles, community values, AI principles, event philosophy) needed almost no change — it held up.
+
+### Changed
+- `governance.md` — Rewrote the Organizer Team section to reflect the real structure: a Founder and Executive Director plus contracted specialists (Diego Mendoza, Product Design Lead; Saige Sufrin, Brand Designer & Creative Director) in defined roles, rather than a flat, titleless organizer group. Split the terminology: "organizer" now names the Founder and Executive Director's role specifically; "team" and "team member" cover the group including paid contractors. Marked the Communications/Outreach and Partnerships/Ecosystem zones as currently unstaffed rather than implying they're covered. Added a section explaining the two-entity structure (PhilaCon Valley, LLC and PhilaCon Valley, Inc.). Added a "Moving Toward a Board" section noting that conversations with potential board members are underway, without naming candidates. Adjusted the "what organizers are not" framing — kept the service-over-power ethos, dropped the claim of flat equality now that titles and pay are real. Replaced Slack references with Discord throughout.
+- `builder-philosophy.md` — Added a section naming both tracks builders work on: nonprofit community programs and LLC agency client work. States plainly why the agency arm exists (it funds the nonprofit, and that independence is still being built, not yet achieved), names the real tension between the "not for clout" ethos and client-driven work instead of glossing over it, and connects paid agency work to the community's confidence-building goal.
+- `community-guidelines.md` — Filled in the byline (previously blank). Replaced the promise of a "designated reporting channel" in onboarding materials — which doesn't exist yet — with an honest description of how to report today. Added an explicit recusal path for reports about a team member, including what happens if the report is about the Founder and Executive Director. Replaced "organizer" with "team"/"team member" to match governance.md's terminology split. Replaced Slack references with Discord.
+- `CODE_OF_CONDUCT.md` — Replaced Slack with Discord in scope. Rewrote Enforcement to offer multiple report paths (any team member, not just one email address), added the 48-hour acknowledgment commitment and the same recusal path as community-guidelines.md, and pointed to community-guidelines.md as the single source of truth for the full process instead of maintaining a second, diverging one.
+- `README.md` — Added Discord as a fourth layer in the documentation model (updated "three-layer" to "four-layer" accordingly), added a Discord invite link to Connect, and linked CHANGELOG.md from the Contributing section.
+- `CONTRIBUTING.md` — Replaced "organizers" with "team" to match the terminology split. Added a Discord-based contribution path for community members who aren't on GitHub. Connected this document's lightweight process to governance.md's fuller Propose → Listen → Decide → Communicate process for meaningful handbook changes.
+- `mission.md`, `principles.md`, `community-values.md`, `ai-principles.md`, `event-philosophy.md` — Reviewed against the current state of the organization; no content changes needed. Last Reviewed date updated to reflect that review.
+- Versioned to 1.1.0 to mark this as a structural update, not a full re-release.
+
+---
+
 ## [1.0.0] — 2026-03-12
 
 The handbook's first complete release. All core documents are drafted, reviewed for voice and consistency, and ready for community input.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -24,11 +24,15 @@ PhilaCon Valley is a community for Black, Brown, LGBTQIA+, and underrepresented 
 
 ## Scope
 
-This Code of Conduct applies in all PhilaCon Valley community spaces — GitHub, events, Slack, social media, and anywhere someone is representing the community.
+This Code of Conduct applies in all PhilaCon Valley community spaces — GitHub, events, Discord, social media, and anywhere someone is representing the community.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to community leaders at **waskar@philaconvalley.com**. All complaints will be reviewed and investigated promptly and fairly. Community leaders are obligated to respect the privacy and security of the reporter.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to any PhilaCon Valley team member — in person, through Discord, or by email at **waskar@philaconvalley.com**. You'll hear back within 48 hours confirming your report was received and is being reviewed. All complaints will be reviewed and investigated promptly and fairly, and the team respects the privacy and security of the reporter.
+
+**If the report is about a team member**, that person is recused from every part of handling it — listening, deciding, and communicating the outcome. If the report is about the Founder and Executive Director, the other team members handle it directly, without the Founder involved in any part of the process.
+
+For the full reporting and enforcement process, including what happens step by step after a report comes in, see [Community Guidelines](governance/community-guidelines.md).
 
 ### Consequences
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ You don't need to be a developer to contribute, and you don't need a GitHub acco
 ## Ways to Contribute
 
 ### Not on GitHub? Say it in Discord.
-Most of this community lives in [Discord](https://discord.gg/WvCB6yxWJD), not GitHub. If something in the handbook feels incomplete, unclear, or off, raise it there — in a resources or feedback channel, or directly with a team member. Someone on the team will turn it into a GitHub Issue if it needs one. You never have to touch Git to have a say in this document.
+Most of this community lives in [Discord](https://discord.gg/5haHYh5xcx), not GitHub. If something in the handbook feels incomplete, unclear, or off, raise it there — in a resources or feedback channel, or directly with a team member. Someone on the team will turn it into a GitHub Issue if it needs one. You never have to touch Git to have a say in this document.
 
 ### Suggest a change to an existing document
 If you're comfortable with GitHub, open a GitHub Issue and describe what you'd change and why. You don't need to write the replacement text yourself, though it helps.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,22 +3,25 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
-First — thank you for wanting to contribute. This handbook belongs to the community, and the best version of it is one that reflects many voices, not just the organizers'.
+First — thank you for wanting to contribute. This handbook belongs to the community, and the best version of it is one that reflects many voices, not just the team's.
 
-You don't need to be a developer to contribute. If you can read a document and have a thought about it, you can help.
+You don't need to be a developer to contribute, and you don't need a GitHub account either. If you can read a document and have a thought about it, you can help.
 
 ---
 
 ## Ways to Contribute
 
+### Not on GitHub? Say it in Discord.
+Most of this community lives in [Discord](https://discord.gg/WvCB6yxWJD), not GitHub. If something in the handbook feels incomplete, unclear, or off, raise it there — in a resources or feedback channel, or directly with a team member. Someone on the team will turn it into a GitHub Issue if it needs one. You never have to touch Git to have a say in this document.
+
 ### Suggest a change to an existing document
-If something feels incomplete, unclear, or off — open a GitHub Issue and describe what you'd change and why. You don't need to write the replacement text yourself, though it helps.
+If you're comfortable with GitHub, open a GitHub Issue and describe what you'd change and why. You don't need to write the replacement text yourself, though it helps.
 
 ### Propose a new document or section
-If you think there's something missing from the handbook — a topic, a perspective, a document type — open an Issue and make the case for it. Good ideas are welcome regardless of where they come from.
+If you think there's something missing from the handbook — a topic, a perspective, a document type — open an Issue (or raise it in Discord) and make the case for it. Good ideas are welcome regardless of where they come from.
 
 ### Submit a pull request
 If you're comfortable with GitHub, you can fork the repository, make your changes, and open a pull request. Keep changes focused — one idea per PR makes it easier to review and discuss.
@@ -31,7 +34,7 @@ If you're comfortable with GitHub, you can fork the repository, make your change
 
 **Be specific.** Vague suggestions are hard to act on. If you think something is missing, say what it is. If something is wrong, say why.
 
-**Expect a conversation.** Contributions may be discussed before being merged. That's not a rejection — it's how we make sure changes reflect the community, not just one person's opinion.
+**Expect a conversation.** Contributions may be discussed before being merged. That's not a rejection — it's how we make sure changes reflect the community, not just one person's opinion. A small fix — a typo, a broken link, a clarifying sentence — usually just gets merged. A meaningful change to the handbook's direction — the mission, the values, the governance structure — follows the fuller Propose → Listen → Decide → Communicate process described in [Governance](governance/governance.md#how-decisions-get-made). Your Issue or PR is the "propose" step either way; the size of the change determines how much "listen" happens before a decision.
 
 **Respect the existing voice.** This doesn't mean you can't challenge ideas — you can and should. But changes should feel continuous with the values and tone already here, not like a departure from them.
 
@@ -48,4 +51,4 @@ Documents are marked with one of the following statuses at the top:
 
 ## Questions?
 
-Open an issue or reach out to the organizers. We're not precious about this — if something is confusing, we want to know.
+Open an issue or reach out to the team. We're not precious about this — if something is confusing, we want to know.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This handbook is the source of truth for our philosophy, values, and culture —
 ## Core Documents
 
 ### Foundation
+- [What We Believe](foundation/vision.md) — Our vision, in full: why we're here and what we build toward
 - [Mission](foundation/mission.md) — Why we exist and what we're working toward
 - [Principles](foundation/principles.md) — How we operate and make decisions
 - [Community Values](foundation/community-values.md) — What we believe and how we show up for each other
@@ -44,7 +45,7 @@ PhilaCon Valley uses a four-layer documentation model:
 | **Google Drive** | Internal operations: event planning, meeting notes, outreach, strategy |
 | **Website** | Public-facing storytelling: mission, community overview, event info |
 
-If you're looking for working documents or event logistics, check Google Drive. If you're looking to talk to people, join the [Discord](https://discord.gg/WvCB6yxWJD). If you're looking for what PhilaCon Valley fundamentally believes and how it operates, you're in the right place.
+If you're looking for working documents or event logistics, check Google Drive. If you're looking to talk to people, join the [Discord](https://discord.gg/5haHYh5xcx). If you're looking for what PhilaCon Valley fundamentally believes and how it operates, you're in the right place.
 
 ---
 
@@ -71,7 +72,7 @@ All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md
 ## Connect
 
 - [Website](https://www.philaconvalley.com/)
-- [Discord](https://discord.gg/WvCB6yxWJD)
+- [Discord](https://discord.gg/5haHYh5xcx)
 - [Meetup](https://www.meetup.com/philaconvalley/)
 - [Luma](https://lu.ma/philaconvalley)
 - [LinkedIn](https://www.linkedin.com/company/philaconvalley/)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 PhilaCon Valley is a community for Black, Brown, LGBTQIA+, and underrepresented technologists in Philadelphia. We bring together engineers, designers, founders, and the tech-curious to learn, build, and belong together.
@@ -35,15 +35,16 @@ This handbook is the source of truth for our philosophy, values, and culture —
 
 ## Where Documentation Lives
 
-PhilaCon Valley uses a three-layer documentation model:
+PhilaCon Valley uses a four-layer documentation model:
 
 | Layer | What lives here |
 |---|---|
 | **GitHub (this repo)** | Core philosophy, values, principles, governance — the source of truth |
+| **Discord** | Day-to-day community — conversation, events, questions, belonging |
 | **Google Drive** | Internal operations: event planning, meeting notes, outreach, strategy |
 | **Website** | Public-facing storytelling: mission, community overview, event info |
 
-If you're looking for working documents or event logistics, check Google Drive. If you're looking for what PhilaCon Valley fundamentally believes and how it operates, you're in the right place.
+If you're looking for working documents or event logistics, check Google Drive. If you're looking to talk to people, join the [Discord](https://discord.gg/WvCB6yxWJD). If you're looking for what PhilaCon Valley fundamentally believes and how it operates, you're in the right place.
 
 ---
 
@@ -59,7 +60,7 @@ This handbook belongs to the community. If you have a suggestion, a correction, 
 
 **You don't need to be a developer to contribute.** If you can read a document and have a thought about it, you can help. Look for issues labeled `good first issue` to get started.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to get involved.
+See [CONTRIBUTING.md](CONTRIBUTING.md) to learn how to get involved. See [CHANGELOG.md](CHANGELOG.md) for a history of what's changed in this handbook.
 
 ## Code of Conduct
 
@@ -70,6 +71,7 @@ All participants are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md
 ## Connect
 
 - [Website](https://www.philaconvalley.com/)
+- [Discord](https://discord.gg/WvCB6yxWJD)
 - [Meetup](https://www.meetup.com/philaconvalley/)
 - [Luma](https://lu.ma/philaconvalley)
 - [LinkedIn](https://www.linkedin.com/company/philaconvalley/)

--- a/foundation/community-values.md
+++ b/foundation/community-values.md
@@ -3,7 +3,7 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 Values aren't just words on a page — they're how we act when no one is watching and how we hold each other when things get hard. These are the values that define PhilaCon Valley.

--- a/foundation/mission.md
+++ b/foundation/mission.md
@@ -3,7 +3,7 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 PhilaCon Valley exists to make Philadelphia the tech hub it's meant to be — built by us, for us.

--- a/foundation/principles.md
+++ b/foundation/principles.md
@@ -3,7 +3,7 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 These are the principles that guide how PhilaCon Valley operates — how we show up, make decisions, and grow together.

--- a/foundation/vision.md
+++ b/foundation/vision.md
@@ -1,0 +1,73 @@
+# What We Believe
+
+> **Status:** Draft — open for community input
+> **Authored by:** Waskar Paulino
+> **Reviewed by:** —
+> **Last Reviewed:** 2026-08-15
+> **Finalized:** —
+
+We are here to make Philadelphia the tech hub it's meant to be —
+built by us, for us.
+
+To turn curiosity over credentials into a real skill,
+to turn sound, code, and visuals into one thing three strangers built in a night,
+to build things that matter, with people we trust, in a city we love.
+
+---
+
+## At our best
+
+We give more than we take.
+From the community, to the person beside us at a build night.
+We become a place where you don't have to earn your place —
+belonging is the starting point, not the reward.
+
+We draw strength from our differences.
+Black, Brown, LGBTQIA+, and underrepresented technologists —
+not a niche audience here. The audience.
+No code-switching. No gatekeeping.
+
+We build real things, not clout.
+Sound, visuals, code, brand, hardware, events —
+PATCH nights where three crafts patch into one build,
+an R&D lab where ideas get tested before they're proven,
+proof you made something, not a story about almost making it.
+
+We keep it real.
+Good vibes doesn't mean fake energy — it means a room safe enough
+for real talk: the question you've been sitting on,
+the place you're stuck, the truth about where you actually are.
+
+We find courage.
+To show unfinished work.
+To ask for help without embarrassment.
+To fail in public and keep building anyway.
+To do it again next PATCH.
+
+---
+
+## At our core
+
+We believe craft is care, not perfection.
+Whether it's code, a design, a workshop, or a conversation —
+we bring intention to what we make.
+
+We believe generosity compounds.
+What we give — an introduction, a critique, an hour of help —
+comes back to the community tenfold.
+
+We believe accountability is how trust survives disagreement.
+We own our mistakes. We say so when we get it wrong.
+We keep it open.
+
+We believe AI amplifies the builder — it doesn't replace them.
+The craft, the judgment, the care for the person on the other side
+of what we build: that stays human.
+
+We believe our soul is our community.
+People who show up before they're asked.
+People who mentor instead of gatekeep.
+People building Philly's tech scene
+because nobody else was going to build it for us.
+
+**Built by us. Owned by us. Judged by what we ship.**

--- a/foundation/vision.md
+++ b/foundation/vision.md
@@ -60,7 +60,7 @@ We believe accountability is how trust survives disagreement.
 We own our mistakes. We say so when we get it wrong.
 We keep it open.
 
-We believe AI amplifies the builder — it doesn't replace them.
+We believe technology amplifies the builder — it doesn't replace them.
 The craft, the judgment, the care for the person on the other side
 of what we build: that stays human.
 

--- a/governance/community-guidelines.md
+++ b/governance/community-guidelines.md
@@ -1,9 +1,9 @@
 # Community Guidelines
 
 > **Status:** Draft — open for community input
-> **Authored by:** —
+> **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** —
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 PhilaCon Valley is built on a simple promise: everyone who walks through the door — physically or digitally — belongs here. These guidelines exist to protect that promise. They apply everywhere the community gathers: in-person events, online channels, collaborative projects, and any space that carries the PhilaCon Valley name.
@@ -94,11 +94,11 @@ Our events are built to be spaces of belonging. That takes everyone's participat
 
 If you experience or witness behavior that violates these guidelines, we want to know. You have several options:
 
-**Talk to an organizer directly.** At in-person events, organizers will be identifiable and approachable. Pull one aside — this is exactly what we're here for.
+**Talk to a team member directly.** At in-person events, the team will be identifiable and approachable. Pull one aside — this is exactly what we're here for.
 
-**Send a message.** If you'd rather not report in person, reach out to the organizer team through our designated reporting channel. Details will be shared in onboarding materials and pinned in online spaces.
+**Send a message.** If you'd rather not report in person, reach out to any team member directly through community channels. A dedicated reporting channel and anonymous form are not built yet — until they are, any team member you contact will treat your report with the same seriousness this document describes.
 
-**Report anonymously.** We will maintain an anonymous reporting form so that anyone can flag a concern without attaching their name to it. Anonymity is respected — no exceptions.
+**Report anonymously.** An anonymous reporting form is planned but not yet built. Once it exists, anonymity will be respected with no exceptions — this section will be updated with a link when it's live.
 
 All reports will be taken seriously. You will not be penalized for raising a concern in good faith.
 
@@ -106,17 +106,19 @@ All reports will be taken seriously. You will not be penalized for raising a con
 
 ## Enforcement
 
-When a report is received, the organizer team will:
+When a report is received, the team will:
 
 **Acknowledge.** You'll hear back within 48 hours confirming that your report was received and is being reviewed.
 
-**Listen.** The organizer team will look into what happened and talk to the people involved. Both the person who reported and the person reported will have a chance to share their perspective.
+**Listen.** The team will look into what happened and talk to the people involved. Both the person who reported and the person reported will have a chance to share their perspective.
 
 **Respond.** What happens next depends on the situation. It might be a private conversation and a request to change behavior, a formal warning, a temporary step-back from spaces or events, or — in serious cases — permanent removal from the community. The response fits the situation.
 
 **Follow up.** We'll let you know the situation was addressed. We won't share private details about the other person, but you won't be left in the dark either.
 
-Organizers make the final call on enforcement. We'll always aim for fairness — but when fairness and safety are in tension, safety wins.
+The team makes the final call on enforcement. We'll always aim for fairness — but when fairness and safety are in tension, safety wins.
+
+**If the report is about a team member.** The team is three people today, so we say this plainly instead of leaving you to guess: the person a report is about is recused from every part of handling that report — listening, deciding, and communicating the outcome. If the report is about the Founder and Executive Director, the other team members handle it directly, without the Founder in the room for any part of the process. We don't yet have an outside party to escalate to if that's not enough — that gap closes once a board is seated (see [Governance](governance.md)). Until then, if you're not comfortable with this, tell us that directly and we'll work out another way to hear you.
 
 ---
 

--- a/governance/governance.md
+++ b/governance/governance.md
@@ -3,7 +3,7 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 PhilaCon Valley is community-stewarded. That means governance is kept lightweight, transparent, and open to evolution as the community grows. But lightweight doesn't mean undefined — it means we write down how things work so that trust is built on clarity, not assumption.
@@ -12,29 +12,49 @@ Think of this document as the operating agreement for how PhilaCon Valley makes 
 
 ---
 
-## The Organizer Team
+## How PhilaCon Valley Is Organized
 
-PhilaCon Valley is run by a small core team of organizers — currently two to four people who share responsibility for the community's direction and day-to-day operations. This is not a board, not a hierarchy, and not a volunteer committee. It's a group of people who care deeply about this community and have stepped up to steward it.
+PhilaCon Valley operates as two connected legal entities, built to serve two different kinds of work:
 
-### What organizers do
+**PhilaCon Valley, LLC** is the agency arm. It packages proven community content into paid client work for outside businesses.
 
-Organizers are responsible for the work that keeps the community running and growing. Rather than everyone doing everything, each organizer has an area of focus — a zone they own and drive. This keeps things moving without creating bottlenecks or duplication.
+**PhilaCon Valley, Inc.** is the nonprofit arm (formation in progress). It runs the community-facing programs — Builder Nights, workshops, hackathons, and the R&D lab where new ideas get tested before the LLC turns them into packaged offerings for clients.
 
-**Community stewardship.** Protecting the culture, values, and identity of PhilaCon Valley. This means making sure the community stays true to its mission as it scales — that the space built for Black, Brown, LGBTQIA+, and underrepresented technologists doesn't drift into something generic. The person focused here is paying attention to how members experience the community and whether the culture matches what we say it is.
+The two entities share a mission and a name, but serve different purposes: the nonprofit exists to build the community; the LLC exists to sustain it financially and prove out what the community builds. See [Builder Philosophy](../philosophy/builder-philosophy.md) for how both kinds of work fit under one idea of what a "builder" is.
 
-**Events and programming.** Designing, coordinating, and running all PhilaCon Valley events — from Builder Nights to hackathons. This includes venue logistics, content planning, facilitation, and the thousand small details that make an event feel intentional rather than thrown together.
+---
 
-**Communications and outreach.** Managing community channels — Slack, social media, event platforms, and the website. Speaking on behalf of the community publicly and keeping members informed. The person focused here is the bridge between the organizer team and the broader community.
+## The Team
 
-**Partnerships and ecosystem.** Building relationships with venues, sponsors, collaborators, and other organizations in the Philly tech ecosystem. This person decides who we work with and on what terms, guided by the community's values — not by who offers the most money or visibility.
+PhilaCon Valley is led by a Founder and Executive Director, who holds overall responsibility for the community's direction and day-to-day operations, supported by contracted specialists who each own a defined area of the work. "Organizer" describes the Founder and Executive Director's community-leadership role; Diego and Saige hold contractor titles for the work they own, not the word "organizer" — the distinction matters because their relationship to the community is a paid, defined engagement, not a volunteer one.
 
-**Conflict resolution and enforcement.** Handling reports, mediating disagreements, and making enforcement decisions. This responsibility is shared across the team rather than owned by one person. The full framework for how this works — what gets reported, how it's handled, and what the consequences look like — lives in the [Community Guidelines](community-guidelines.md).
+### What the team does
 
-These areas of focus are flexible, not rigid. Everyone on the organizer team pitches in across areas when needed — especially at events. The zones exist to make sure nothing falls through the cracks, not to create silos.
+Each person has an area of focus — a zone they own and drive. This keeps things moving without creating bottlenecks or duplication.
 
-### What organizers are not
+**Community stewardship and overall direction** — Founder and Executive Director. Holds final responsibility for the community's mission, culture, and direction — making sure the space built for Black, Brown, LGBTQIA+, and underrepresented technologists doesn't drift into something generic as it scales, and making the final call on decisions that affect the community as a whole.
 
-Organizers are not authorities. They don't have special status in discussions or more valid opinions than any other member. The role is about service and stewardship — holding responsibility so the community can focus on building. The moment organizing becomes about power rather than purpose, something has gone wrong.
+**Product design** — Diego Mendoza, Product Design Lead. Shapes how the community's programs, tools, and experiences are designed and delivered — from workshop formats to the design-intake pipeline that turns ideas into shippable work.
+
+**Brand and creative direction** — Saige Sufrin, Brand Designer & Creative Director. Stewards the visual identity, brand voice, and creative direction of PhilaCon Valley across events, communications, and public-facing materials.
+
+**Communications and outreach** — open. Nobody owns this zone yet. Until it's staffed, this work falls to whoever on the team has capacity.
+
+**Partnerships and ecosystem** — open. Nobody owns this zone yet. Until it's staffed, this work falls to whoever on the team has capacity.
+
+**Conflict resolution and enforcement.** Handling reports, mediating disagreements, and making enforcement decisions. The full framework for how this works — what gets reported, how it's handled, and what the consequences look like — lives in the [Community Guidelines](community-guidelines.md).
+
+These areas of focus are flexible, not rigid. Everyone pitches in across areas when needed — especially at events. The zones exist to make sure nothing falls through the cracks, not to create silos.
+
+### What organizing means here
+
+Holding a title and getting paid for a role is not the same as holding unchecked power. The role is still about service and stewardship — using the responsibility and context that come with a title to make the community stronger, not to put distance between the team and members. Titles describe who owns what and who is accountable for it. They do not mean someone's opinion counts for more in a conversation about culture, values, or what the community needs. The moment this work becomes about power rather than purpose, something has gone wrong.
+
+---
+
+## Moving Toward a Board
+
+As PhilaCon Valley's nonprofit arm takes shape, the community is moving toward its first governing board — the "co-leadership" evolution described later in this document is already underway, not just a future possibility. Conversations with potential board members are in progress. Nothing is seated yet, and this document will be updated with real names and structure once a board exists. Until then, the Founder and Executive Director and the team continue to hold operational responsibility as described above.
 
 ---
 
@@ -44,43 +64,43 @@ Not all decisions are the same, and they shouldn't all be made the same way. Phi
 
 ### Day-to-day decisions
 
-Event logistics, scheduling, channel management, communications — these are made by organizers as they come up. The community trusts organizers to handle the operational work without needing to poll the room every time. Speed matters here. We bias toward action and iteration over prolonged debate. We'd rather try something, learn from it, and adjust than wait for perfect consensus.
+Within their own zone — scheduling, communications, a product-design call, a brand call — the team member who owns that zone decides as things come up. The community trusts the team to handle operational work without needing to poll the room every time. Speed matters here. We bias toward action and iteration over prolonged debate. We'd rather try something, learn from it, and adjust than wait for perfect consensus.
 
 ### Significant decisions
 
 Changes that affect the community's direction, culture, or structure — like introducing a new event format, forming a partnership, changing how we communicate, or updating the handbook in a meaningful way — follow a different process:
 
-**Propose.** An organizer (or any community member) puts the idea forward — in Slack, at an event, or through a GitHub Issue. The proposal should be clear about what's changing, why, and what it would look like.
+**Propose.** A team member (or any community member) puts the idea forward — in Discord, at an event, or through a GitHub Issue. The proposal should be clear about what's changing, why, and what it would look like.
 
-**Listen.** The community has space to weigh in. This might be a dedicated discussion thread, a conversation at an event, or a simple poll. The goal is to hear from people who will be affected — not to reach unanimous agreement, but to surface perspectives the organizers might be missing.
+**Listen.** The community has space to weigh in. This might be a dedicated discussion thread, a conversation at an event, or a simple poll. The goal is to hear from people who will be affected — not to reach unanimous agreement, but to surface perspectives the team might be missing.
 
-**Decide.** Organizers make the final call, informed by what they heard. If the decision diverges from what the community expressed, organizers explain why. Transparency isn't optional — it's how trust survives disagreement.
+**Decide.** The Founder and Executive Director makes the final call on community-wide decisions, informed by what they heard and by input from the rest of the team. If the decision diverges from what the community expressed, they explain why. Transparency isn't optional — it's how trust survives disagreement.
 
 **Communicate.** The decision is shared with the community along with the reasoning behind it. No backroom moves. No surprises.
 
 ### The principle behind it
 
-This is a "listen, then lead" model. It respects that organizers have context and responsibility that the broader community doesn't, while also recognizing that no small group has a monopoly on good ideas. The community's input shapes the decision. The organizers own it.
+This is a "listen, then lead" model. It respects that the team has context and responsibility that the broader community doesn't, while also recognizing that no small group has a monopoly on good ideas. The community's input shapes the decision. The Founder and Executive Director owns the final call.
 
 ---
 
-## Becoming an Organizer
+## Joining the Team
 
-There is no application form, no election, and no job posting. Organizers emerge from the community — people who show up consistently, contribute meaningfully, and demonstrate the values PhilaCon Valley is built on.
+There is no application form, no election, and no job posting. Team members emerge from the community — people who show up consistently, contribute meaningfully, and demonstrate the values PhilaCon Valley is built on. In practice, that relationship is later formalized with a title and a paid contractor agreement — but the role starts as trust earned, not a position applied for.
 
 ### What "showing up" looks like
 
-It's not just attending events. It's the person who stays after to help clean up. The one who notices a newcomer standing alone and walks over. The member who volunteers to run a workshop, gives thoughtful feedback on a handbook draft, or quietly makes the Slack channels better by how they engage. Organizer energy is visible long before the title is formalized.
+It's not just attending events. It's the person who stays after to help clean up. The one who notices a newcomer standing alone and walks over. The member who volunteers to run a workshop, gives thoughtful feedback on a handbook draft, or quietly makes the Discord channels better by how they engage. This energy is visible long before a title is formalized.
 
 ### How it happens
 
-When the existing organizer team recognizes that someone has been consistently contributing at that level — and when there's a genuine need for additional capacity — they'll have a direct conversation with that person. It starts with an honest discussion about what the role involves, what the time commitment looks like, and whether it's the right fit for both sides.
+When the existing team recognizes that someone has been consistently contributing at that level — and when there's a genuine need for additional capacity — they'll have a direct conversation with that person. It starts with an honest discussion about what the role involves, what the time commitment looks like, and whether it's the right fit for both sides.
 
 There's no probation period or trial run, but there is an expectation: if you take on the role, you follow through. Reliability matters more than enthusiasm.
 
 ### Stepping back
 
-Life changes. Priorities shift. If an organizer needs to step back — temporarily or permanently — that's respected without judgment. The community doesn't run on guilt. What we ask is that you communicate early so the team can adjust, and that any ongoing responsibilities are handed off cleanly.
+Life changes. Priorities shift. If a team member needs to step back — temporarily or permanently — that's respected without judgment. The community doesn't run on guilt. What we ask is that you communicate early so the team can adjust, and that any ongoing responsibilities are handed off cleanly.
 
 ---
 
@@ -90,19 +110,19 @@ PhilaCon Valley is not a fixed thing. The community will change as it grows, and
 
 ### Where we are now
 
-A small core team handles everything. That works because the community is young and the trust is personal — members know the organizers, and organizers know the members. Decisions are fast, feedback loops are short, and accountability is face-to-face.
+A small team with defined roles handles the work, and the first board conversations are underway. That still works because the community is young and the trust is personal — members know the team, and the team knows the members. Decisions are fast, feedback loops are short, and accountability is face-to-face.
 
 ### Where we're heading
 
 As the community grows, we anticipate the need for more structure — not because structure is inherently good, but because the informal systems that work at small scale start to break. Here's how we're thinking about that evolution:
 
-**Advisory roles.** As PhilaCon Valley connects with more of the Philly tech ecosystem, we may invite community members or external allies to serve in advisory capacities — offering perspective on partnerships, programming, or growth without taking on operational responsibilities. Advisors would be chosen for their alignment with the community's values and their ability to see things the organizer team might miss.
+**Advisory roles.** As PhilaCon Valley connects with more of the Philly tech ecosystem, we may invite community members or external allies to serve in advisory capacities — offering perspective on partnerships, programming, or growth without taking on operational responsibilities. Advisors would be chosen for their alignment with the community's values and their ability to see things the team might miss.
 
 **Workgroups.** For specific initiatives — a hackathon series, a mentorship program, a content project — we may form temporary workgroups with their own leads and timelines. These aren't permanent committees. They form around a need, do the work, and dissolve when it's done. This distributes ownership without building bureaucracy.
 
-**Co-leadership.** If the community reaches a size where a small team can't steward it effectively, the organizer structure will need to evolve. This might mean formalizing co-lead roles with clearly defined areas of responsibility, or creating a leadership council that shares decision-making authority more broadly.
+**Co-leadership.** If the community reaches a size where a small team can't steward it effectively, the team's structure will need to evolve. This might mean formalizing co-lead roles with clearly defined areas of responsibility, or creating a leadership council that shares decision-making authority more broadly.
 
-**Succession planning.** No community should be fragile enough to collapse if one person leaves. As the organizer team grows, we'll document institutional knowledge, distribute critical relationships, and make sure that the systems, accounts, and processes that keep PhilaCon Valley running are accessible to more than one person. The goal is a community that outlasts any individual contributor — including its founders.
+**Succession planning.** No community should be fragile enough to collapse if one person leaves. As the team grows, we'll document institutional knowledge, distribute critical relationships, and make sure that the systems, accounts, and processes that keep PhilaCon Valley running are accessible to more than one person. The goal is a community that outlasts any individual contributor — including its founders.
 
 ### What won't change
 

--- a/philosophy/ai-principles.md
+++ b/philosophy/ai-principles.md
@@ -8,6 +8,8 @@
 
 AI is part of the landscape now. It's in our tools, our workflows, and increasingly in the products we create. At PhilaCon Valley, we don't shy away from it — but we don't center our identity on it either. AI is one of many things our members build with, think about, and learn from. It's part of the conversation, not the whole conversation.
 
+When we do build with AI, the skill we teach and practice is **agentic engineering** — using AI as a working partner inside a real build, not a one-off trick. We've run single workshops on narrower formats before (a "vibe coding" session, for instance) — those are fine as one-time explorations, but they're not what defines how we build here. Agentic engineering is the ongoing thing.
+
 These principles guide how we — both as individual builders and as a community organization — approach AI with intention, honesty, and care.
 
 ---

--- a/philosophy/ai-principles.md
+++ b/philosophy/ai-principles.md
@@ -3,7 +3,7 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 AI is part of the landscape now. It's in our tools, our workflows, and increasingly in the products we create. At PhilaCon Valley, we don't shy away from it — but we don't center our identity on it either. AI is one of many things our members build with, think about, and learn from. It's part of the conversation, not the whole conversation.

--- a/philosophy/builder-philosophy.md
+++ b/philosophy/builder-philosophy.md
@@ -3,7 +3,7 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 At PhilaCon Valley, "builder" isn't a job title. It's a posture.
@@ -30,6 +30,18 @@ Many of us come from backgrounds where we were told — explicitly or implicitly
 
 We give feedback that lifts. We celebrate small wins. We make space for the question that feels embarrassing to ask. Confidence is a resource we build together.
 
+Getting paid, professional-grade work through the agency arm is part of that same confidence-building — proof, not just encouragement, that you belong in this industry.
+
 ## We are Philly builders.
 
 We aren't trying to replicate Silicon Valley. Philly has its own energy, its own culture, its own history of people building things against the odds. Our work is rooted here — and that's a feature, not a limitation.
+
+## Building happens on two tracks — and both count.
+
+PhilaCon Valley builds through a nonprofit arm and an agency arm, working side by side. The nonprofit runs the community-tier work — workshops, hackathons, the R&D lab where ideas get tested first. The agency arm takes proven ideas and packages them into paid work for outside clients.
+
+We're honest about why: client work funds the community. Workshops, venues, and the people who run them cost money. The agency arm exists so the nonprofit doesn't have to depend on outside grants or goodwill alone to keep running. We're early — one client, one track record — and we're building toward that independence, not claiming we've already arrived.
+
+The two tracks ask different questions. Community work asks "what do we want to make?" Client work asks "what does this client need?" That's a real difference, not a small one — and we don't pretend otherwise. A client brief looks like waiting for permission, and in a narrow sense it is — but the builder's posture doesn't disappear inside it. Deciding how to solve the client's problem, pushing back when a shortcut would hurt the result, bringing craft to work nobody's watching closely — that's the same instinct that shows up in a hackathon, aimed at a different target. What doesn't change between the two tracks is the standard: craft over shortcuts, honesty about what AI did and didn't do, and care for the person the work is for — whether that person is a community member or a paying client.
+
+We hold client work to the same test the Partnerships principle sets for everything else: we choose who we work with based on fit with our values, not on who pays the most. If a client's ask runs against what this community stands for, we say no — the same way we would with a sponsor or a venue.

--- a/philosophy/builder-philosophy.md
+++ b/philosophy/builder-philosophy.md
@@ -45,3 +45,11 @@ We're honest about why: client work funds the community. Workshops, venues, and 
 The two tracks ask different questions. Community work asks "what do we want to make?" Client work asks "what does this client need?" That's a real difference, not a small one — and we don't pretend otherwise. A client brief looks like waiting for permission, and in a narrow sense it is — but the builder's posture doesn't disappear inside it. Deciding how to solve the client's problem, pushing back when a shortcut would hurt the result, bringing craft to work nobody's watching closely — that's the same instinct that shows up in a hackathon, aimed at a different target. What doesn't change between the two tracks is the standard: craft over shortcuts, honesty about what AI did and didn't do, and care for the person the work is for — whether that person is a community member or a paying client.
 
 We hold client work to the same test the Partnerships principle sets for everything else: we choose who we work with based on fit with our values, not on who pays the most. If a client's ask runs against what this community stands for, we say no — the same way we would with a sponsor or a venue.
+
+## The line between the two tracks stays a line.
+
+Support flows one direction between the two arms: the agency can fund and back the nonprofit — sponsorship, in-kind work, revenue. The nonprofit never becomes a funnel for the agency. Coming to a workshop or a build night does not put you on a client list.
+
+In practice, that means three things. **We don't start the sales conversation.** If you ask whether the agency could build something for you, we'll answer honestly — but nobody raises it first inside community space. **Community members get no pricing advantage** for being community members; a discount would just turn free programming into a marketing cost for paid work, which is the exact thing we're avoiding. **When a conversation does cross from community to client work, we say so out loud** — "that's a different thing now, that's the agency side, here's what it costs" — instead of letting the shift happen quietly.
+
+This isn't a nice-to-have. It's what keeps "client work funds the community" true, instead of becoming "the community funds client work" without anyone noticing.

--- a/philosophy/event-philosophy.md
+++ b/philosophy/event-philosophy.md
@@ -14,11 +14,13 @@ Our events are not networking nights. They are not pitch competitions or resume 
 
 We run a mix of event types because different moments call for different formats:
 
-- **Builder Nights** — Hands-on sessions. Pair programming, creative coding, open builds. You leave having made something.
-- **Vision Labs** — Space to think bigger. Discussions, lightning talks, idea-sharing around where we're headed and what we're building toward.
+- **PATCH** — Our flagship build night. One theme, one night, hands-on the whole time. You leave having made something and understanding how it works. Running since June 2026 (PATCH 001, PATCH 002, and counting).
 - **Workshops** — Focused skill-building with a clear goal. You come in not knowing something and leave knowing it.
+- **Vision Labs** — Space to think bigger. Discussions, lightning talks, idea-sharing around where we're headed and what we're building toward.
 - **Hackathons** — Longer sprints. Build something real with people you may have just met. Designed to produce both projects and relationships.
 - **The Giveback** — Events centered on returning value to the community — whether through mentorship, resource sharing, or celebrating each other.
+
+PATCH is proven — it's the format we run and keep running. Workshops, Vision Labs, Hackathons, and The Giveback are formats we're building toward. As each one runs for real, this list will say so.
 
 ## We keep it real.
 

--- a/philosophy/event-philosophy.md
+++ b/philosophy/event-philosophy.md
@@ -3,7 +3,7 @@
 > **Status:** Draft — open for community input
 > **Authored by:** Waskar Paulino
 > **Reviewed by:** —
-> **Last Reviewed:** 2026-03-12
+> **Last Reviewed:** 2026-08-15
 > **Finalized:** —
 
 Our events are not networking nights. They are not pitch competitions or resume drops. They are gatherings — spaces where people who build things come together to learn, make, connect, and feel at home.


### PR DESCRIPTION
## Summary
- Rewrote governance.md, builder-philosophy.md, community-guidelines.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, and README.md to match how PhilaCon Valley actually operates now (contracted team roles, two-entity structure, board-in-progress, Discord as a fourth doc layer).
- Fixed event-philosophy.md: named PATCH as the flagship, running build-night series instead of the unused "Builder Nights" label.
- Added the Community/Agency Boundary Policy in plain terms to builder-philosophy.md — the nonprofit never starts the sales conversation, no pricing advantage for community members, crossovers to client work are said out loud.
- Clarified ai-principles.md: agentic engineering is the ongoing skill; "vibe coding" was a one-time workshop, not the identity.
- Updated the Discord invite link across README.md and CONTRIBUTING.md.
- Added `foundation/vision.md`, a new "What We Believe" vision statement built from language already used across the handbook and the community's own comms — sound, visuals, code, and brand, not code alone.
- Logged all of the above in CHANGELOG.md (1.1.0 and 1.1.1).

## Test plan
- [ ] Read through foundation/vision.md and confirm the tone matches the rest of the handbook
- [ ] Confirm the Discord links resolve (discord.gg/5haHYh5xcx)
- [ ] Spot-check that PATCH naming reads correctly alongside the Discord `#workshop-track` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)